### PR TITLE
fix(store): bigint input as string to prevent 000..000 masking

### DIFF
--- a/src/indexer/indexClaimsStored.ts
+++ b/src/indexer/indexClaimsStored.ts
@@ -65,7 +65,7 @@ export const indexClaimsStoredEvents = async ({
         storeHypercertContract({
           contract: {
             ...contract,
-            last_block_indexed: toBock,
+            last_block_indexed: toBlock,
           },
         }),
       );

--- a/src/storage/storeHypercerts.ts
+++ b/src/storage/storeHypercerts.ts
@@ -1,4 +1,4 @@
-import { supabase } from "../clients/supabaseClient";
+import { supabase } from "@/clients/supabaseClient";
 import { Tables } from "@/types/database.types";
 
 /* 
@@ -38,6 +38,7 @@ export const storeHypercerts = async ({
     .filter((data) => data !== undefined)
     .map((hypercert) => ({
       ...hypercert,
+      claim_id: hypercert.claim_id?.toString(),
       hypercert_contracts_id: contract.id,
     }));
 

--- a/src/utils/getDeployment.ts
+++ b/src/utils/getDeployment.ts
@@ -29,7 +29,7 @@ export const getDeployment = (): Partial<Deployment> & {
         startBlock: 4421944n,
         easAddress: "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
         schemaRegistryAddress: "0x0a7E2Ff54e76B8E6659aedc9103FB21c038050D0",
-        chainI,
+        chainId,
       };
     default:
       throw new Error(`Unsupported chain ID: ${chainId}`);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -2,4 +2,4 @@ insert into public.hypercert_contracts (chain_id, contract_address)
 values (11155111, '0xa16DFb32Eb140a6f3F2AC68f41dAd8c7e83C4941');
 
 insert into public.supported_schemas (chain_id, eas_schema_id, last_block_indexed)
-values (11155111, '0x6fc5f6423ba06f5ce1fd293d0eee50c24adf802e085fae755ad7296e35dd3f00', 5387663);
+values (11155111, '0x3c0d0488e4d50455ef511f2c518403d21d35aa671ca30644aa9f7f7bb2516e2f', 5387663);


### PR DESCRIPTION
* Input claimIDs as strings in supabase-js because bigint got parsed as number resulting in 340282366920938460000000000000000000000 instead of 340282366920938463463374607431768211456