### PR TITLE
fix(nullable): default values for allowlist records

### DIFF
--- a/supabase/migrations/20240521095300_mint_claim_from_allowlist.sql
+++ b/supabase/migrations/20240521095300_mint_claim_from_allowlist.sql
@@ -1,8 +1,8 @@
 alter table "public"."hypercert_allow_list_records" add column "claimed" boolean not null default false;
 
-alter table "public"."hypercert_allow_list_records" add column "leaf" text not null;
+alter table "public"."hypercert_allow_list_records" add column "leaf" text not null default '';
 
-alter table "public"."hypercert_allow_list_records" add column "proof" jsonb not null;
+alter table "public"."hypercert_allow_list_records" add column "proof" jsonb not null default '{}'::jsonb;
 
 CREATE OR REPLACE FUNCTION store_allow_list_records(
     _claims_id UUID,


### PR DESCRIPTION
* Migration had new not null columns. This broke the migration because the DB already had records