### PR TITLE
Fix/metadata fetching loop

### DIFF
--- a/src/indexer/indexClaimsStored.ts
+++ b/src/indexer/indexClaimsStored.ts
@@ -20,7 +20,7 @@ import { storeClaim } from "@/storage/storeClaim";
  */
 
 const defaultConfig = {
-  batchSize: 20000n,
+  batchSize: 10000n,
   eventName: "ClaimStored",
 };
 

--- a/src/parsing/transferSingleEvent.ts
+++ b/src/parsing/transferSingleEvent.ts
@@ -37,7 +37,8 @@ export const parseTransferSingle = async (event: unknown) => {
     block_timestamp: await getBlockTimestamp(event.blockNumber),
     block_number: event.blockNumber,
     value: args.value,
-    owner_address: args.to,
+    to_owner_address: args.to,
+    from_owner_address: args.from,
   };
 
   return row;

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,8 +71,8 @@ app.listen(port, async () => {
   const indexingMethods = [
     indexSupportedSchemas,
     indexClaimsStoredEvents,
-    indexTransferSingleEvents,
     indexUnitTransfers,
+    indexTransferSingleEvents,
     indexMetadata,
     indexAllowListData,
     indexAllowlistRecords,

--- a/src/storage/storeMetadata.ts
+++ b/src/storage/storeMetadata.ts
@@ -85,7 +85,6 @@ export const storeMetadata = async ({ metadata }: StoreMetadata) => {
     parsed: true,
   }));
 
-  console.log(parsedMetadata.map((x) => x.uri));
   try {
     await supabase
       .from("metadata")

--- a/src/storage/storeMetadata.ts
+++ b/src/storage/storeMetadata.ts
@@ -80,8 +80,12 @@ export const storeMetadata = async ({ metadata }: StoreMetadata) => {
       "impact_timeframe_from must be less than impact_timeframe_to, unless impact_timeframe_to is infinite (0)",
     );
 
-  const parsedMetadata = metadata.map((x) => metadataValidationSchema.parse(x));
+  const parsedMetadata = metadata.map((x) => ({
+    ...metadataValidationSchema.parse(x),
+    parsed: true,
+  }));
 
+  console.log(parsedMetadata.map((x) => x.uri));
   try {
     await supabase
       .from("metadata")

--- a/src/storage/storeTransferSingleFraction.ts
+++ b/src/storage/storeTransferSingleFraction.ts
@@ -58,25 +58,28 @@ export const storeTransferSingleFraction = async ({
         claims_id: claim.id,
         token_id: transfer.token_id.toString(),
         creation_block_timestamp: transfer.block_timestamp.toString(),
-        last_block_update_timestamp: transfer.block_timestamp.toString(),
-        owner_address: transfer.owner_address,
+        block_timestamp: transfer.block_timestamp.toString(),
+        from_owner_address: transfer.from_owner_address,
+        to_owner_address: transfer.to_owner_address,
         value: transfer.value.toString(),
       };
     }),
   );
 
-  console.log(`[StoreTransferSingleFraction] Storing ${tokens.length} tokens`);
+  console.debug(
+    `[StoreTransferSingleFraction] Storing ${tokens.length} tokens`,
+  );
 
   const sortedUniqueTokens = _(tokens)
     .orderBy(["last_block_update_timestamp"], ["desc"])
     .uniqBy("token_id")
     .value();
 
-  console.log(
+  console.debug(
     `[StoreTransferSingleFraction] Found ${sortedUniqueTokens.length} unique tokens`,
   );
 
   return await supabase
-    .rpc("store_fraction", { _fractions: sortedUniqueTokens })
+    .rpc("transfer_fractions_batch", { p_transfers: sortedUniqueTokens })
     .throwOnError();
 };

--- a/src/storage/updateAllowlistRecordClaimed.ts
+++ b/src/storage/updateAllowlistRecordClaimed.ts
@@ -29,7 +29,7 @@ export const updateAllowlistRecordClaimed = async ({
         "metadata.allow_list_data.hypercert_allow_lists.hypercert_allow_list_records.claimed",
         false,
       )
-      .single()
+      .maybeSingle()
       .throwOnError();
 
     const hypercertAllowListRecordId =

--- a/src/types/database-generated.types.ts
+++ b/src/types/database-generated.types.ts
@@ -541,6 +541,12 @@ export type Database = {
         }
         Returns: undefined
       }
+      transfer_fractions_batch: {
+        Args: {
+          p_transfers: Database["public"]["CompositeTypes"]["transfer_fractions_type"][]
+        }
+        Returns: undefined
+      }
       transfer_units_batch: {
         Args: {
           p_transfers: Database["public"]["CompositeTypes"]["transfer_units_type"][]
@@ -564,6 +570,14 @@ export type Database = {
         contract_id: string | null
         token_id: number | null
         root: string | null
+      }
+      transfer_fractions_type: {
+        claims_id: string | null
+        token_id: number | null
+        from_owner_address: string | null
+        to_owner_address: string | null
+        block_timestamp: number | null
+        value: number | null
       }
       transfer_units_type: {
         claim_id: string | null

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -38,7 +38,8 @@ export type NewTransfer = {
   block_timestamp: bigint;
   block_number: bigint;
   value: bigint;
-  owner_address: string;
+  from_owner_address: string;
+  to_owner_address: string;
   type: "claim" | "fraction";
 };
 

--- a/supabase/migrations/20240522093552_update_functions_null_parsing.sql
+++ b/supabase/migrations/20240522093552_update_functions_null_parsing.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION check_uri_and_insert_into_metadata()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    IF NEW.uri IS NOT NULL AND NOT EXISTS (SELECT 1 FROM metadata WHERE uri = NEW.uri) THEN
+        INSERT INTO metadata (uri) VALUES (NEW.uri);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20240522093552_update_functions_null_parsing.sql
+++ b/supabase/migrations/20240522093552_update_functions_null_parsing.sql
@@ -8,3 +8,114 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION transfer_units_batch(p_transfers transfer_units_type[])
+    RETURNS void
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    transfer   transfer_units_type;
+    from_token fractions%ROWTYPE;
+BEGIN
+    FOR transfer IN SELECT * FROM unnest(p_transfers)
+        LOOP
+            -- handle from token state change
+            IF transfer.from_token_id != 0 THEN
+                IF EXISTS (SELECT 1
+                           FROM fractions
+                           WHERE fractions.token_id = transfer.from_token_id
+                             AND fractions.claims_id = transfer.claim_id) THEN
+                    -- If from_token_id exists, update its units, when units would be less than 0, throw an error
+                    SELECT *
+                    INTO from_token
+                    FROM fractions
+                    WHERE fractions.token_id = transfer.from_token_id
+                      AND fractions.claims_id = transfer.claim_id
+                        FOR UPDATE;
+
+                    IF from_token.units - transfer.units_transferred < 0 THEN
+                        RAISE EXCEPTION 'Insufficient units in from_token_id %', transfer.from_token_id;
+                    END IF;
+
+                    UPDATE from_token
+                    SET units                       = units - transfer.units_transferred,
+                        last_block_update_timestamp = transfer.block_timestamp
+                    WHERE fractions.token_id = transfer.to_token_id
+                      AND fractions.claims_id = transfer.claim_id;
+                ELSE
+                    -- If to_token_id does not exist, create it but do not update its units
+                    INSERT INTO fractions (claims_id, token_id, creation_block_timestamp,
+                                           last_block_update_timestamp)
+                    VALUES (transfer.claim_id, transfer.to_token_id,
+                            transfer.block_timestamp,
+                            transfer.block_timestamp);
+                END IF;
+            END IF;
+
+            -- handle to token state change
+            IF EXISTS (SELECT 1
+                       FROM fractions
+                       WHERE fractions.token_id = transfer.to_token_id
+                         AND fractions.claims_id = transfer.claim_id) THEN
+                -- If to_token_id exists, update its units
+                UPDATE fractions
+                SET units                       = units + transfer.units_transferred,
+                    last_block_update_timestamp = transfer.block_timestamp
+                WHERE fractions.token_id = transfer.to_token_id
+                  AND fractions.claims_id = transfer.claim_id;
+            ELSE
+                -- If to_token_id does not exist, create it with the provided amount of units
+                INSERT INTO fractions (claims_id, token_id, units, creation_block_timestamp,
+                                       last_block_update_timestamp)
+                VALUES (transfer.claim_id, transfer.to_token_id, transfer.units_transferred, transfer.block_timestamp,
+                        transfer.block_timestamp);
+            END IF;
+        END LOOP;
+END;
+$$;
+
+create type transfer_fractions_type as
+(
+    claims_id          uuid,
+    token_id           numeric(78, 0),
+    from_owner_address text,
+    to_owner_address   text,
+    block_timestamp    numeric(78, 0),
+    value              numeric(78, 0)
+);
+
+CREATE OR REPLACE FUNCTION transfer_fractions_batch(p_transfers transfer_fractions_type[])
+    RETURNS void
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    transfer transfer_fractions_type;
+BEGIN
+    FOR transfer IN SELECT * FROM unnest(p_transfers)
+        LOOP
+            IF EXISTS (SELECT 1
+                       FROM fractions
+                       WHERE fractions.token_id = transfer.token_id
+                         AND fractions.claims_id = transfer.claims_id) THEN
+                -- If to_token_id exists, update its units
+                UPDATE fractions
+                SET claims_id                   = transfer.claims_id,
+                    owner_address               = transfer.to_owner_address,
+                    creation_block_timestamp    = COALESCE(creation_block_timestamp, transfer.block_timestamp),
+                    last_block_update_timestamp = COALESCE(transfer.block_timestamp, last_block_update_timestamp),
+                    value                       = COALESCE(value, transfer.value)
+                WHERE fractions.token_id = transfer.token_id
+                  AND fractions.claims_id = transfer.claims_id;
+            ELSE
+                -- If to_token_id does not exist, create it with the provided amount of units
+                INSERT INTO fractions (claims_id, token_id, value, owner_address, creation_block_timestamp,
+                                       last_block_update_timestamp)
+                VALUES (transfer.claims_id, transfer.token_id, transfer.value, transfer.to_owner_address,
+                        transfer.block_timestamp,
+                        transfer.block_timestamp);
+            END IF;
+        END LOOP;
+END;
+$$;


### PR DESCRIPTION
* Flag parsed metadata as parsed
* Skip inserting metadata URIs when they are NULL
* Allow 0-returned rows on updateAllowListRecordsClaimed by setting as `maybeSingle`
* Create new function for storing fraction transfer so that fraction and unit transfers are complementary on `fractions` rows
* Added migration for DB changes