### PR TITLE
fix(id): defaultToNull to false for autogenerating ids

### DIFF
--- a/src/storage/storeTransferSingleFraction.ts
+++ b/src/storage/storeTransferSingleFraction.ts
@@ -126,6 +126,9 @@ export const storeTransferSingleFraction = async ({
 
   return await supabase
     .from("fractions")
-    .upsert(sortedUniqueTokens, { ignoreDuplicates: false })
+    .upsert(sortedUniqueTokens, {
+      ignoreDuplicates: false,
+      defaultToNull: false,
+    })
     .throwOnError();
 };

--- a/src/storage/storeUnits.ts
+++ b/src/storage/storeUnits.ts
@@ -180,6 +180,9 @@ export const storeUnitTransfer = async ({ transfers }: StoreUnitTransfer) => {
 
   await supabase
     .from("fractions")
-    .upsert(parsedTokens, { ignoreDuplicates: false })
+    .upsert(parsedTokens, {
+      ignoreDuplicates: false,
+      defaultToNull: false,
+    })
     .throwOnError();
 };

--- a/src/types/database-generated.types.ts
+++ b/src/types/database-generated.types.ts
@@ -1004,6 +1004,10 @@ export type Database = {
           updated_at: string
         }[]
       }
+      operation: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       search: {
         Args: {
           prefix: string


### PR DESCRIPTION
defautlToNull to false to fix `[runIndexing] Failed to index events PostgrestError: null value in column "id" of relation "fractions" violates not-null constraint`