### PR TITLE
fix: match addresses lowercased

### DIFF
--- a/src/storage/storeTransferSingleFraction.ts
+++ b/src/storage/storeTransferSingleFraction.ts
@@ -65,10 +65,11 @@ export const storeTransferSingleFraction = async ({
 
       if (
         token?.owner_address &&
-        token.owner_address !== transfer.from_owner_address
+        token.owner_address.toLowerCase() !==
+          transfer.from_owner_address.toLowerCase()
       ) {
         console.error(
-          `[StoreTransferSingleFraction] Error while getting token; owner address mismatch.`,
+          `[StoreTransferSingleFraction] Error while getting token; owner address mismatch. [${(token.owner_address.toLowerCase(), transfer.from_owner_address.toLowerCase())}]`,
           tokenError,
         );
         return;

--- a/src/storage/storeUnits.ts
+++ b/src/storage/storeUnits.ts
@@ -40,7 +40,6 @@ export const storeUnitTransfer = async ({ transfers }: StoreUnitTransfer) => {
 
   await Promise.all(
     transfers.map(async (transfer) => {
-      console.log("TRANSFER: ", transfer);
       let fromToken = tokens.find(
         (token) => token.token_id === transfer.from_token_id.toString(),
       );
@@ -63,7 +62,7 @@ export const storeUnitTransfer = async ({ transfers }: StoreUnitTransfer) => {
       }
 
       if (!claimId) {
-        console.error(`[StoreUnitTransfer] Could net get claim_id.`);
+        console.error(`[StoreUnitTransfer] Could net create or get claim_id.`);
         return;
       }
 

--- a/test/parsing/transferSingleEvent.test.ts
+++ b/test/parsing/transferSingleEvent.test.ts
@@ -10,7 +10,7 @@ import { getAddress } from "viem";
 
 describe("transferSingleEvent", {}, () => {
   const from = getAddress(faker.finance.ethereumAddress());
-  const timestamp = 10;
+  const timestamp = 10n;
   const contractAddress = getAddress(faker.finance.ethereumAddress());
   const operatorAddress = getAddress(faker.finance.ethereumAddress());
   const fromAddress = getAddress(faker.finance.ethereumAddress());

--- a/test/parsing/valueTransferEvent.test.ts
+++ b/test/parsing/valueTransferEvent.test.ts
@@ -14,7 +14,7 @@ describe("valueTransferEvent", () => {
   const value = faker.number.bigInt();
   const address = getAddress(faker.finance.ethereumAddress());
   const blockNumber = faker.number.bigInt();
-  const timestamp = faker.number.int();
+  const timestamp = faker.number.bigInt();
 
   const event = {
     address,

--- a/test/storage/storeTransferSingleFraction.test.ts
+++ b/test/storage/storeTransferSingleFraction.test.ts
@@ -9,7 +9,7 @@ import { getAddress } from "viem";
 describe("storeTransferSingleFraction", () => {
   const transfer = {
     block_number: faker.number.bigInt(),
-    contract_address: faker.finance.ethereumAddress(),
+    contract_address: faker.finance.ethereumAddress().toString(),
     value: faker.number.bigInt(),
     block_timestamp: faker.number.bigInt(),
     from_owner_address: getAddress(faker.finance.ethereumAddress()),


### PR DESCRIPTION
* Removes redundant logging of TRANSFER while logging unit transfer
* Matched token owners on lowercased addresses