### PR TITLE
fix(metadata): cleanup metadata validation

### DIFF
--- a/src/fetching/fetchMetadataFromUri.ts
+++ b/src/fetching/fetchMetadataFromUri.ts
@@ -1,6 +1,5 @@
-import { HypercertMetadata, validateMetaData } from "@hypercerts-org/sdk";
-import { Tables } from "@/types/database.types.js";
 import { fetchFromHttpsOrIpfs } from "@/utils/fetchFromHttpsOrIpfs.js";
+import { HypercertMetadataValidator } from "@/utils/metadata.zod.js";
 
 /*
  * This function fetches the metadata of a claim from the uri as stored in the claim on the contract.
@@ -39,19 +38,19 @@ export const fetchMetadataFromUri = async ({ uri }: FetchMetadataFromUri) => {
     return;
   }
 
-  const { valid, data, errors } = validateMetaData(fetchResult);
+  const res = HypercertMetadataValidator.safeParse(fetchResult);
 
-  if (!valid) {
+  if (!res.success) {
     console.warn(
       `[FetchMetadataFromUri] Invalid metadata for URI ${uri}`,
-      errors,
+      res.error,
     );
     return;
   }
 
-  const _metadata = data as HypercertMetadata;
+  const _metadata = res.data;
 
-  const metadata: Partial<Tables<"metadata">> = {
+  return {
     name: _metadata.name,
     description: _metadata.description,
     external_url: _metadata.external_url,
@@ -67,6 +66,4 @@ export const fetchMetadataFromUri = async ({ uri }: FetchMetadataFromUri) => {
     rights: _metadata.hypercert?.rights?.value,
     allow_list_uri: _metadata.allowList,
   };
-
-  return metadata;
 };

--- a/src/indexer/indexMetadata.ts
+++ b/src/indexer/indexMetadata.ts
@@ -1,7 +1,6 @@
 import { IndexerConfig } from "@/types/types.js";
 import { getMissingMetadataUris } from "@/storage/getMissingMetadataUris.js";
 import { storeMetadata } from "@/storage/storeMetadata.js";
-import { Tables } from "@/types/database.types.js";
 import { fetchMetadataFromUri } from "@/fetching/fetchMetadataFromUri.js";
 
 /*
@@ -54,10 +53,8 @@ const processMetadataBatch = async (batch: string[]) => {
         ...(await fetchMetadataFromUri({ uri })),
       })),
     )
-  ).filter(
-    (metadata): metadata is Tables<"metadata"> =>
-      metadata !== null && metadata !== undefined,
-  );
+  ).filter((metadata) => metadata !== null && metadata !== undefined);
 
+  // @ts-expect-error properties[] cannot be mapped to JSON
   await storeMetadata({ metadata });
 };

--- a/src/storage/storeMetadata.ts
+++ b/src/storage/storeMetadata.ts
@@ -1,6 +1,5 @@
 import { supabase } from "@/clients/supabaseClient.js";
 import { Database } from "@/types/database.types.js";
-import { z } from "zod";
 
 /* 
     This function stores the chain, contract address, token ID, metadata and URI of a hypercert in the database.
@@ -36,61 +35,17 @@ export const storeMetadata = async ({ metadata }: StoreMetadata) => {
 
   console.debug(`[StoreMetadata] Storing ${metadata.length} metadata entries`);
 
-  const metadataValidationSchema = z
-    .object({
-      allow_list_uri: z.string().optional(),
-      contributors: z.array(z.string()).optional(),
-      description: z.string().optional(),
-      external_url: z.string().optional(),
-      id: z.string().optional(),
-      image: z.string().optional(),
-      impact_scope: z.array(z.string()).optional(),
-      impact_timeframe_from: z.number().optional(),
-      impact_timeframe_to: z.number().optional(),
-      name: z.string().optional(),
-      properties: z
-        .array(
-          z.object({
-            trait_type: z.string(),
-            value: z.any(),
-          }),
-        )
-        .optional(),
-      rights: z.array(z.string()).optional(),
-      uri: z.string().optional(),
-      work_scope: z.array(z.string()).optional(),
-      work_timeframe_from: z.number().optional(),
-      work_timeframe_to: z.number().optional(),
-    })
-    .refine(
-      (x) =>
-        x.work_timeframe_from !== undefined && x.work_timeframe_to !== undefined
-          ? x.work_timeframe_to === 0 ||
-            x.work_timeframe_from <= x.work_timeframe_to
-          : true,
-      "work_timeframe_from must be less than work_timeframe_to, unless work_timeframe_to is infinite (0)",
-    )
-    .refine(
-      (x) =>
-        x.impact_timeframe_from !== undefined &&
-        x.impact_timeframe_to !== undefined
-          ? x.impact_timeframe_to === 0 ||
-            x.impact_timeframe_from <= x.impact_timeframe_to
-          : true,
-      "impact_timeframe_from must be less than impact_timeframe_to, unless impact_timeframe_to is infinite (0)",
-    );
-
-  const parsedMetadata = metadata.map((x) => ({
-    ...metadataValidationSchema.parse(x),
-    parsed: true,
-  }));
-
   try {
     await supabase
       .from("metadata")
-      .upsert(parsedMetadata, { onConflict: "uri", ignoreDuplicates: false })
+      .upsert(metadata, {
+        onConflict: "uri",
+        ignoreDuplicates: false,
+        defaultToNull: true,
+      })
       .throwOnError();
   } catch (error) {
     console.error("[StoreMetadata] Error while storing parsed metadata", error);
+    throw error;
   }
 };

--- a/src/utils/metadata.zod.ts
+++ b/src/utils/metadata.zod.ts
@@ -1,0 +1,59 @@
+import { HypercertMetadata, HypercertClaimdata } from "@hypercerts-org/sdk";
+import { z } from "zod";
+
+const claimData: z.ZodType<HypercertClaimdata> = z.object({
+  impact_scope: z.object({
+    name: z.string(),
+    value: z.array(z.string()),
+    excludes: z.array(z.string()),
+    display_value: z.string(),
+  }),
+  work_scope: z.object({
+    name: z.string(),
+    value: z.array(z.string()),
+    excludes: z.array(z.string()),
+    display_value: z.string(),
+  }),
+  work_timeframe: z.object({
+    name: z.string(),
+    value: z.array(z.number()),
+    display_value: z.string(),
+  }),
+  impact_timeframe: z.object({
+    name: z.string(),
+    value: z.array(z.number()),
+    display_value: z.string(),
+  }),
+  contributors: z.object({
+    name: z.string(),
+    value: z.array(z.string()),
+    display_value: z.string(),
+  }),
+  rights: z.object({
+    name: z.string(),
+    value: z.array(z.string()),
+    excludes: z.array(z.string()),
+    display_value: z.string(),
+  }),
+});
+
+const HypercertMetadataValidator: z.ZodType<HypercertMetadata> = z.object({
+  name: z.string(),
+  description: z.string(),
+  external_url: z.string().optional(),
+  image: z.string(),
+  version: z.string().optional(),
+  ref: z.string().optional(),
+  allowList: z.string().optional(),
+  properties: z
+    .array(
+      z.object({
+        trait_type: z.string().optional(),
+        value: z.string().optional(),
+      }),
+    )
+    .optional(),
+  hypercert: claimData,
+});
+
+export { HypercertMetadataValidator };


### PR DESCRIPTION
Replace the metadata schema validation because for storage purposes we want to store all metadata that matches our format, even when for instance timestamps don't make sense.

* Create single Zod schema for metadata validation that only validated on the correct types
* Remove duplicated validation steps
* Replaces `validateMetadata` from SDK with zod schema