### PR TITLE
fix(allowlist): indexing allowlist records

### DIFF
--- a/seed.ts
+++ b/seed.ts
@@ -97,7 +97,7 @@ const main = async () => {
     {
       chain_id: 11155111,
       contract_address: "0xa16DFb32Eb140a6f3F2AC68f41dAd8c7e83C4941",
-      start_block: 5237421,
+      start_block: 4421945,
       contract_slug: minterContractSlug,
     },
     {

--- a/seed.ts
+++ b/seed.ts
@@ -97,7 +97,7 @@ const main = async () => {
     {
       chain_id: 11155111,
       contract_address: "0xa16DFb32Eb140a6f3F2AC68f41dAd8c7e83C4941",
-      start_block: 4421945,
+      start_block: 5237421,
       contract_slug: minterContractSlug,
     },
     {

--- a/src/fetching/fetchMetadataFromUri.ts
+++ b/src/fetching/fetchMetadataFromUri.ts
@@ -43,7 +43,7 @@ export const fetchMetadataFromUri = async ({ uri }: FetchMetadataFromUri) => {
   if (!res.success) {
     console.warn(
       `[FetchMetadataFromUri] Invalid metadata for URI ${uri}`,
-      res.error,
+      res.error.message,
     );
     return;
   }

--- a/src/indexer/indexAllowlistSingleClaimMinted.ts
+++ b/src/indexer/indexAllowlistSingleClaimMinted.ts
@@ -1,12 +1,13 @@
 import { parseLeafClaimedEvent } from "@/parsing/leafClaimedEvent.js";
 import { getDeployment } from "@/utils/getDeployment.js";
-import { IndexerConfig, LeafClaimed } from "@/types/types.js";
+import { IndexerConfig } from "@/types/types.js";
 import { getContractEventsForChain } from "@/storage/getContractEventsForChain.js";
 import { updateLastBlockIndexedContractEvents } from "@/storage/updateLastBlockIndexedContractEvents.js";
 import { getLogsForContractEvents } from "@/monitoring/hypercerts.js";
 import { updateAllowlistRecordClaimed } from "@/storage/updateAllowlistRecordClaimed.js";
 import { supabase } from "@/clients/supabaseClient.js";
 import { client } from "@/clients/evmClient.js";
+import { getAddress } from "viem";
 
 /*
  * This function indexes the logs of the LeafClaimed event emitted by the HypercertMinter contract. Based on the last
@@ -34,6 +35,11 @@ export const indexAllowlistSingleClaimMinted = async ({
     eventName,
   });
 
+  if (!contractsWithEvents || contractsWithEvents.length === 0) {
+    console.debug("[IndexAllowlistSingleClaimMinted] No contract events found");
+    return;
+  }
+
   const currentBlock = await client.getBlockNumber();
   const currentEventsClaimStored = await getContractEventsForChain({
     eventName: "ClaimStored",
@@ -52,24 +58,24 @@ export const indexAllowlistSingleClaimMinted = async ({
   // Do batch size based on latest indexed allowlist data for current chain
   const latestIndexedHypercertAllowlist = await supabase
     .from("hypercert_allowlists_with_claim")
-    .select("block_number")
+    .select("creation_block_number")
     .like("hypercert_id", `${chainId}-%`)
-    .order("block_number", { ascending: false })
+    .order("creation_block_number", { ascending: false })
     .limit(1)
     .maybeSingle();
 
   const latestIndexedAllowlistClaimBlock = latestIndexedHypercertAllowlist?.data
-    ?.block_number as number | undefined;
+    ?.creation_block_number as number | undefined;
 
   if (latestIndexedAllowlistClaimBlock === undefined) {
+    console.debug(
+      `[IndexAllowlistSingleClaimMinted] No allowlists found for chain ${chainId}`,
+    );
     // No allowlists known, so nothing to index
     return;
   }
 
-  if (!contractsWithEvents || contractsWithEvents.length === 0) {
-    return;
-  }
-
+  console.log("PARSING CLAIMS FROM ALLOWLISTS");
   const results = await Promise.all(
     contractsWithEvents.flatMap(async (contractEvent) => {
       const { last_block_indexed } = contractEvent;
@@ -95,29 +101,29 @@ export const indexAllowlistSingleClaimMinted = async ({
         : maxEndBlock - fromBlock;
 
       // Get logs in batches
-      const logsFound = await getLogsForContractEvents({
+      const { logs, toBlock } = await getLogsForContractEvents({
         fromBlock,
         batchSize: adjustedBatchSize,
         contractEvent,
       });
 
-      if (!logsFound) {
+      if (logs.length === 0) {
         console.debug(
-          " [IndexAllowlistSingleClaimMinted] No logs found for contract event",
+          " [IndexAllowlistSingleClaimMinted] No logs found for Leaf Claimed event",
           contractEvent,
         );
-        return;
+        return {
+          contractEventUpdate: {
+            ...contractEvent,
+            last_block_indexed: toBlock,
+          },
+        };
       }
-
-      const { logs, toBlock } = logsFound;
 
       // parse logs to get claimID, contractAddress and cid
       const parsedEvents = (
         await Promise.all(logs.map(parseLeafClaimedEvent))
-      ).filter(
-        (claim): claim is Partial<LeafClaimed> =>
-          claim !== null && claim !== undefined,
-      );
+      ).filter((claim) => claim !== null && claim !== undefined);
 
       const claims = parsedEvents.map((claim) => ({
         ...claim,
@@ -136,23 +142,30 @@ export const indexAllowlistSingleClaimMinted = async ({
 
   const claims = results
     .flatMap((result) => (result?.claims ? result.claims : undefined))
-    .filter(
-      (claim): claim is LeafClaimed => claim !== null && claim !== undefined,
-    );
+    .filter((claim) => claim !== null && claim !== undefined);
+
+  if (claims.length === 0) {
+    await updateLastBlockIndexedContractEvents({
+      contract_events: results.flatMap((res) =>
+        res?.contractEventUpdate ? [res.contractEventUpdate] : [],
+      ),
+    });
+  }
 
   await Promise.all(
     claims.map(async (claim) => {
       return updateAllowlistRecordClaimed({
         tokenId: claim.token_id,
         leaf: claim.leaf,
-        userAddress: claim.creator_address as `0x${string}`,
+        userAddress: claim.creator_address,
       });
     }),
+  ).then(
+    async () =>
+      await updateLastBlockIndexedContractEvents({
+        contract_events: results.flatMap((res) =>
+          res?.contractEventUpdate ? [res.contractEventUpdate] : [],
+        ),
+      }),
   );
-
-  await updateLastBlockIndexedContractEvents({
-    contract_events: results.flatMap((res) =>
-      res?.contractEventUpdate ? [res.contractEventUpdate] : [],
-    ),
-  });
 };

--- a/src/indexer/indexAllowlistSingleClaimMinted.ts
+++ b/src/indexer/indexAllowlistSingleClaimMinted.ts
@@ -75,7 +75,6 @@ export const indexAllowlistSingleClaimMinted = async ({
     return;
   }
 
-  console.log("PARSING CLAIMS FROM ALLOWLISTS");
   const results = await Promise.all(
     contractsWithEvents.flatMap(async (contractEvent) => {
       const { last_block_indexed } = contractEvent;

--- a/src/parsing/leafClaimedEvent.ts
+++ b/src/parsing/leafClaimedEvent.ts
@@ -32,7 +32,6 @@ const LeafClaimed = z.object({
  * @param event - The event object.
  * */
 export const parseLeafClaimedEvent = async (event: unknown) => {
-  console.log("PARSING LEAF CLAIMED EVENT");
   const { args, blockNumber, address, transactionHash } =
     LeafClaimedSchema.parse(event);
 

--- a/src/parsing/leafClaimedEvent.ts
+++ b/src/parsing/leafClaimedEvent.ts
@@ -1,8 +1,8 @@
 import { isAddress, isHex } from "viem";
 import { getBlockTimestamp } from "@/utils/getBlockTimestamp.js";
-import { LeafClaimed } from "@/types/types.js";
 import { client } from "@/clients/evmClient.js";
 import { z } from "zod";
+import { messages } from "@/utils/validation.js";
 
 const LeafClaimedSchema = z.object({
   address: z.string().refine(isAddress),
@@ -14,6 +14,17 @@ const LeafClaimedSchema = z.object({
   transactionHash: z.string().refine(isHex),
 });
 
+const LeafClaimed = z.object({
+  creator_address: z
+    .string()
+    .refine(isAddress, { message: messages.INVALID_ADDRESS }),
+  token_id: z.bigint(),
+  creation_block_timestamp: z.bigint(),
+  contract_address: z
+    .string()
+    .refine(isAddress, { message: messages.INVALID_ADDRESS }),
+  leaf: z.string(),
+});
 /*
  * Helper method to get the tokenID, contract address, minter address and leaf hash from the event. Will return undefined when the event is
  * missing values.
@@ -21,6 +32,7 @@ const LeafClaimedSchema = z.object({
  * @param event - The event object.
  * */
 export const parseLeafClaimedEvent = async (event: unknown) => {
+  console.log("PARSING LEAF CLAIMED EVENT");
   const { args, blockNumber, address, transactionHash } =
     LeafClaimedSchema.parse(event);
 
@@ -28,13 +40,11 @@ export const parseLeafClaimedEvent = async (event: unknown) => {
     hash: transactionHash,
   });
 
-  const claim: Partial<LeafClaimed> = {
+  return LeafClaimed.parse({
     creator_address: transaction.from,
     token_id: args.tokenID,
     creation_block_timestamp: await getBlockTimestamp(blockNumber),
     contract_address: address,
     leaf: args.leaf,
-  };
-
-  return claim;
+  });
 };

--- a/src/storage/updateAllowlistRecordClaimed.ts
+++ b/src/storage/updateAllowlistRecordClaimed.ts
@@ -12,23 +12,23 @@ export const updateAllowlistRecordClaimed = async ({
   try {
     // Get an allowlist record for corresponding tokenId and leaf that has not been claimed
     const record = await supabase
-      .from("hypercert_allow_list_records_with_token_id")
+      .from("claimable_fractions_with_proofs")
       .select("*")
       .eq("leaf", leaf)
       .eq("user_address", userAddress)
       .eq("claimed", false)
-      .eq("token_id", tokenId)
+      .eq("token_id", tokenId.toString())
       .maybeSingle()
       .throwOnError();
 
     if (!record.data) {
       const alreadyClaimedRecord = await supabase
-        .from("hypercert_allow_list_records_with_token_id")
+        .from("claimable_fractions_with_proofs")
         .select("*")
         .eq("leaf", leaf)
         .eq("user_address", userAddress)
         .eq("claimed", true)
-        .eq("token_id", tokenId)
+        .eq("token_id", tokenId.toString())
         .maybeSingle()
         .throwOnError();
 

--- a/src/types/database-generated.types.ts
+++ b/src/types/database-generated.types.ts
@@ -1004,6 +1004,10 @@ export type Database = {
           updated_at: string
         }[]
       }
+      operation: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       search: {
         Args: {
           prefix: string

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -14,16 +14,6 @@ export type EventToFetch = {
   start_block: bigint;
 };
 
-export type LeafClaimed = {
-  contracts_id: string;
-  creator_address: string;
-  contract_address: string;
-  creation_block_number: bigint;
-  creation_block_timestamp: bigint;
-  token_id: bigint;
-  leaf: string;
-};
-
 export type NewAllowList = {
   contracts_id: string;
   token_id: bigint | string;

--- a/test/parsing/leafClaimedEvent.test.ts
+++ b/test/parsing/leafClaimedEvent.test.ts
@@ -15,7 +15,7 @@ describe("leafClaimedEvent", {}, () => {
         return HttpResponse.json(0);
       }),
     );
-    const address = getAddress(faker.finance.ethereumAddress());
+    const address = faker.finance.ethereumAddress();
     const tokenID = faker.number.bigInt();
     const leaf = faker.string.alphanumeric("10");
     const blockNumber = faker.number.bigInt();
@@ -38,7 +38,7 @@ describe("leafClaimedEvent", {}, () => {
         }) as any,
     );
 
-    const timestamp = 10;
+    const timestamp = 10n;
     const spy = vi.spyOn(client, "getBlock").mockImplementation(
       async () =>
         ({

--- a/test/resources/mockMetadata.ts
+++ b/test/resources/mockMetadata.ts
@@ -18,11 +18,13 @@ export const mockMetadata = {
     impact_scope: {
       name: "Impact Scope",
       value: ["all"],
+      excludes: [],
       display_value: "All",
     },
     work_scope: {
       name: "Work Scope",
       value: ["art design", "metadata standards"],
+      excludes: [],
       display_value: "Art Design & Metadata Standards",
     },
     work_timeframe: {
@@ -43,6 +45,7 @@ export const mockMetadata = {
     rights: {
       name: "Rights",
       value: ["public display", "-transfers"],
+      excludes: [],
       display_value: "Public display",
     },
   },


### PR DESCRIPTION
This PR fixes the allowlist indexing that broke on the updated column names. Some additional improvements were made for more robust processing.

* LeafClaimed as zod typed schema
* Fetch records on `creation_block_number` instead of `block_number`
* Update contract events and abort when no events were found
* Uses `claimable_fractions_with_proofs` view instead of old view