### PR TITLE
fix(bug): get tokens with claimsID to prevent overlap between chains

### DIFF
--- a/src/storage/storeValueTransfer.ts
+++ b/src/storage/storeValueTransfer.ts
@@ -61,6 +61,7 @@ export const storeValueTransfer: StorageMethod<ParsedValueTransfer> = async ({
     .from("fractions")
     .select("*, token_id::text, units::text")
     .eq("token_id", data.from_token_id.toString())
+    .eq("claims_id", claimId.toString())
     .maybeSingle()
     .throwOnError();
 
@@ -79,6 +80,7 @@ export const storeValueTransfer: StorageMethod<ParsedValueTransfer> = async ({
     .from("fractions")
     .select("*, token_id::text, units::text")
     .eq("token_id", data.to_token_id.toString())
+    .eq("claims_id", claimId.toString())
     .maybeSingle()
     .throwOnError();
 


### PR DESCRIPTION
Updates fraction and unit transfer methods to fetch tokens with claims_id, not only token ID. This to prevent access to tokens from a different chain/contracts.