### PR TITLE
feat(cache): cache data calls in local db

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "wait-on": "^7.2.0"
   },
   "dependencies": {
-    "@hypercerts-org/chainsauce": "1.0.22",
+    "@hypercerts-org/chainsauce": "1.0.23-alpha.3",
     "@hypercerts-org/contracts": "2.0.0-alpha.0",
     "@hypercerts-org/marketplace-sdk": "^0.3.13",
     "@hypercerts-org/sdk": "^1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@hypercerts-org/chainsauce':
-        specifier: 1.0.22
-        version: 1.0.22(zod@3.23.8)
+        specifier: 1.0.23-alpha.3
+        version: 1.0.23-alpha.3(zod@3.23.8)
       '@hypercerts-org/contracts':
         specifier: 2.0.0-alpha.0
         version: 2.0.0-alpha.0(ts-node@10.9.2(@swc/core@1.5.25)(@types/node@20.11.19)(typescript@5.5.2))(typescript@5.5.2)
@@ -726,8 +726,8 @@ packages:
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
 
-  '@hypercerts-org/chainsauce@1.0.22':
-    resolution: {integrity: sha512-JaPhi9n0Sh9zCSKP7V34nrbd7xIfuq8QgWPCMfjsXaoNG4yuFFPZuYvejYaFrBhVrtuvGXlGabT9Tzgxet0aiA==}
+  '@hypercerts-org/chainsauce@1.0.23-alpha.3':
+    resolution: {integrity: sha512-r5Kqdz3etiyy7JT2MsdZKv57+JzvDv40vHgJgP+8b1QzLzpzwhZ4X7iErBMBUHLR6ymhJNamNpsu4u0mPZ/M5w==}
 
   '@hypercerts-org/contracts@1.1.2':
     resolution: {integrity: sha512-+Y7TD1LX1c2FyU7OYuQ/NUFfcKaW5fIZ9R/Xr+DhNUbi7KstHhhdVEl1hmSExuvySbAD3wNKFaQWdlBRxT520Q==}
@@ -5597,7 +5597,7 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.2': {}
 
-  '@hypercerts-org/chainsauce@1.0.22(zod@3.23.8)':
+  '@hypercerts-org/chainsauce@1.0.23-alpha.3(zod@3.23.8)':
     dependencies:
       '@types/pg': 8.11.6
       '@types/uuid': 9.0.8

--- a/src/fetching/fetchAllowlistFromUri.ts
+++ b/src/fetching/fetchAllowlistFromUri.ts
@@ -2,6 +2,7 @@ import { fetchFromHttpsOrIpfs } from "@/utils/fetchFromHttpsOrIpfs.js";
 import { parseToOzMerkleTree } from "@/utils/parseToOzMerkleTree.js";
 
 export interface FetchAllowListFromUriInput {
+  fetchMethod: (args: { uri: string }) => Promise<unknown>;
   uri?: string;
 }
 

--- a/src/indexer/LogParser.ts
+++ b/src/indexer/LogParser.ts
@@ -8,10 +8,11 @@ export type ParserContext = {
   contracts_id: string;
   block: Block;
   schema?: Tables<"supported_schemas">;
+  dataFetcher?: (args: { uri: string }) => Promise<unknown>;
 };
 
 export interface ParserMethod<T> {
-  (params: { log: unknown; context: ParserContext }): Promise<T[]>;
+  (params: { data: unknown; context: ParserContext }): Promise<T[]>;
 }
 
 export interface StorageMethod<T> {
@@ -27,9 +28,9 @@ class LogParser<T> {
     this.storage = storage;
   }
 
-  async parse(log: unknown, context: ParserContext): Promise<void> {
+  async parse(data: unknown, context: ParserContext): Promise<void> {
     try {
-      const parsed = await this.parser({ log, context });
+      const parsed = await this.parser({ data, context });
       await this.storage({ data: parsed, context });
     } catch (error) {
       console.error(

--- a/src/indexer/eventHandlers.ts
+++ b/src/indexer/eventHandlers.ts
@@ -47,14 +47,14 @@ export const getEventHandler = (eventName: string) => {
 };
 
 export interface EventParser {
-  log: unknown;
+  data: unknown;
   context: ParserContext;
 }
 
-export const processEvent = async ({ log, context }: EventParser) => {
+export const processEvent = async ({ data, context }: EventParser) => {
   try {
-    const handler = getEventHandler(log.name);
-    await handler.parse(log, context).then(() => {
+    const handler = getEventHandler(data.name);
+    await handler.parse(data, context).then(() => {
       const { contracts_id, events_id, block } = context;
       updateLastBlockIndexedContractEvents({
         contracts_id,

--- a/src/parsing/attestedEvent.ts
+++ b/src/parsing/attestedEvent.ts
@@ -69,7 +69,7 @@ export type ParsedAttestedEvent = z.infer<typeof ParsedAttestedEventSchema>;
  * ```
  */
 export const parseAttestedEvent: ParserMethod<DecodedAttestation> = async ({
-  log,
+  data,
   context: { schema },
 }) => {
   if (!schema) throw new Error("[parseAttestedEvent] Schema not found");
@@ -78,7 +78,7 @@ export const parseAttestedEvent: ParserMethod<DecodedAttestation> = async ({
   const validator = createAttestedEventSchema({ easAddress });
 
   try {
-    const { params } = validator.parse(log);
+    const { params } = validator.parse(data);
 
     const attestedEvent = ParsedAttestedEventSchema.parse({
       recipient: params.recipient,

--- a/src/parsing/batchValueTransferEvent.ts
+++ b/src/parsing/batchValueTransferEvent.ts
@@ -22,8 +22,8 @@ const ValueTransferEventSchema = z.object({
  * */
 export const parseBatchValueTransfer: ParserMethod<
   ParsedValueTransfer
-> = async ({ log }) => {
-  const { params, address } = ValueTransferEventSchema.parse(log);
+> = async ({ data }) => {
+  const { params, address } = ValueTransferEventSchema.parse(data);
 
   const transfers = params.claimIDs.map((claimID, index) => {
     return {

--- a/src/parsing/claimStoredEvent.ts
+++ b/src/parsing/claimStoredEvent.ts
@@ -26,10 +26,10 @@ export type ClaimStoredEvent = z.infer<typeof ClaimStoredEventSchema>;
  * @throws {z.ZodError} If the event does not match the ClaimStoredEventSchema, a Zod validation error is thrown.
  */
 export const parseClaimStoredEvent: ParserMethod<Claim> = async ({
-  log,
-  context: { block, contracts_id },
+  data,
+  context: { contracts_id },
 }) => {
-  const { params, transactionHash } = ClaimStoredEventSchema.parse(log);
+  const { params, transactionHash } = ClaimStoredEventSchema.parse(data);
 
   try {
     const transaction = await client.getTransaction({

--- a/src/parsing/leafClaimedEvent.ts
+++ b/src/parsing/leafClaimedEvent.ts
@@ -32,10 +32,10 @@ export type LeafClaimed = z.infer<typeof LeafClaimed>;
  * @param event - The event object.
  * */
 export const parseLeafClaimedEvent: ParserMethod<LeafClaimed> = async ({
-  log,
+  data,
   context: { block },
 }) => {
-  const { params, address, transactionHash } = LeafClaimedSchema.parse(log);
+  const { params, address, transactionHash } = LeafClaimedSchema.parse(data);
 
   const transaction = await client.getTransaction({
     hash: transactionHash,

--- a/src/parsing/parseTakerBid.ts
+++ b/src/parsing/parseTakerBid.ts
@@ -72,11 +72,11 @@ const TakerBidEventSchema = z.object({
   transactionHash: z.string(),
 });
 
-export const parseTakerBidEvent: ParserMethod<TakerBid> = async ({ log }) => {
+export const parseTakerBidEvent: ParserMethod<TakerBid> = async ({ data }) => {
   const { addresses } = getDeployment();
 
   try {
-    const bid = TakerBidEventSchema.parse(log);
+    const bid = TakerBidEventSchema.parse(data);
 
     // parse logs to get claimID, contractAddress and cid
     const transactionLogs = await client

--- a/src/parsing/transferBatchEvent.ts
+++ b/src/parsing/transferBatchEvent.ts
@@ -21,9 +21,9 @@ const TransferBatchEventSchema = z.object({
  * @param event - The event object.
  * */
 export const parseTransferBatch: ParserMethod<ParsedTransferSingle> = async ({
-  log,
+  data,
 }) => {
-  const { params, address } = TransferBatchEventSchema.parse(log);
+  const { params, address } = TransferBatchEventSchema.parse(data);
 
   return params.ids.map((id, index) =>
     ParsedTransferSingle.parse({

--- a/src/parsing/transferSingleEvent.ts
+++ b/src/parsing/transferSingleEvent.ts
@@ -38,9 +38,9 @@ export type ParsedTransferSingle = z.infer<typeof ParsedTransferSingle>;
  * @param event - The event object.
  * */
 export const parseTransferSingle: ParserMethod<ParsedTransferSingle> = async ({
-  log,
+  data,
 }) => {
-  const { params, address } = TransferSingleEventSchema.parse(log);
+  const { params, address } = TransferSingleEventSchema.parse(data);
 
   return [
     ParsedTransferSingle.parse({

--- a/src/parsing/valueTransferEvent.ts
+++ b/src/parsing/valueTransferEvent.ts
@@ -33,9 +33,9 @@ export type ParsedValueTransfer = z.infer<typeof ParsedValueTransfer>;
  * @param event - The event object.
  * */
 export const parseValueTransfer: ParserMethod<ParsedValueTransfer> = async ({
-  log,
+  data,
 }) => {
-  const { params, address } = ValueTransferEventSchema.parse(log);
+  const { params, address } = ValueTransferEventSchema.parse(data);
 
   return [
     ParsedValueTransfer.parse({

--- a/src/storage/storeClaimStored.ts
+++ b/src/storage/storeClaimStored.ts
@@ -2,10 +2,6 @@ import { supabase } from "@/clients/supabaseClient.js";
 import { isAddress } from "viem";
 import { z } from "zod";
 import { StorageMethod } from "@/indexer/LogParser.js";
-import { indexMetadata } from "@/indexer/indexMetadata.js";
-import { indexAllowListData } from "@/indexer/indexAllowlistData.js";
-import { indexAllowlistRecords } from "@/indexer/indexAllowlistRecords.js";
-import { chainId } from "@/utils/constants.js";
 
 export const ClaimSchema = z.object({
   contracts_id: z.string().optional(),
@@ -76,18 +72,6 @@ export const storeClaimStored: StorageMethod<Claim> = async ({
         ignoreDuplicates: false,
       })
       .throwOnError();
-
-    // TODO is this the best place for handling the additional data fetching?
-
-    const indexingConfig = {
-      batchSize: 10n,
-      chain_id: chainId,
-      context,
-      delay: 0,
-    };
-    await indexMetadata(indexingConfig);
-    await indexAllowListData(indexingConfig);
-    await indexAllowlistRecords(indexingConfig);
   } catch (error) {
     console.error("[StoreClaim] Error storing claims", error);
     throw error;

--- a/src/storage/storeMetadata.ts
+++ b/src/storage/storeMetadata.ts
@@ -29,13 +29,15 @@ export const storeMetadata = async ({
 }: {
   data: Database["public"]["Tables"]["metadata"]["Update"][];
 }) => {
-  if (!data || data.length === 0) {
-    console.error("[StoreMetadata] No data or contract provided");
+  if (data.length === 0) {
+    console.warn("[StoreMetadata] No data to store");
     return;
   }
 
   try {
     const dataToStore = _.unionBy(data, "uri");
+
+    console.log(dataToStore);
 
     await supabase
       .from("metadata")

--- a/src/types/database-generated.types.ts
+++ b/src/types/database-generated.types.ts
@@ -997,6 +997,10 @@ export type Database = {
           updated_at: string
         }[]
       }
+      operation: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       search: {
         Args: {
           prefix: string

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,7 +1,6 @@
 import { ParserContext } from "@/indexer/LogParser.js";
 
 export type IndexerConfig = {
-  chain_id: number;
   delay: number;
   batchSize: bigint;
   context: ParserContext;

--- a/src/utils/fetchFromHttpsOrIpfs.ts
+++ b/src/utils/fetchFromHttpsOrIpfs.ts
@@ -2,7 +2,10 @@ import { fetchFromHTTPS, fetchFromIPFS } from "@/utils/fetching.js";
 
 const DO_NOT_PARSE = ["ipfs://null", "ipfs://", "ipfs://example"];
 
-export const fetchFromHttpsOrIpfs = async (uri?: string): Promise<unknown> => {
+export const fetchFromHttpsOrIpfs = async (args: {
+  uri: string;
+}): Promise<unknown> => {
+  const { uri } = args;
   if (!uri || DO_NOT_PARSE.includes(uri)) {
     console.warn(
       "[fetchFromHttpsOrIpfs] URI is missing or not accepted: ",

--- a/src/utils/metadata.zod.ts
+++ b/src/utils/metadata.zod.ts
@@ -37,23 +37,24 @@ const claimData: z.ZodType<HypercertClaimdata> = z.object({
   }),
 });
 
-const HypercertMetadataValidator: z.ZodType<HypercertMetadata> = z.object({
-  name: z.string(),
-  description: z.string(),
-  external_url: z.string().optional(),
-  image: z.string(),
-  version: z.string().optional(),
-  ref: z.string().optional(),
-  allowList: z.string().optional(),
-  properties: z
-    .array(
-      z.object({
-        trait_type: z.string().optional(),
-        value: z.string().optional(),
-      }),
-    )
-    .optional(),
-  hypercert: claimData,
-});
+export const HypercertMetadataValidator: z.ZodType<HypercertMetadata> =
+  z.object({
+    name: z.string(),
+    description: z.string(),
+    external_url: z.string().optional(),
+    image: z.string(),
+    version: z.string().optional(),
+    ref: z.string().optional(),
+    allowList: z.string().optional(),
+    properties: z
+      .array(
+        z.object({
+          trait_type: z.string().optional(),
+          value: z.string().optional(),
+        }),
+      )
+      .optional(),
+    hypercert: claimData,
+  });
 
-export { HypercertMetadataValidator };
+export type Metadata = z.infer<typeof HypercertMetadataValidator>;


### PR DESCRIPTION
Uses updated chainsauce instance that adds a caching layer for data calls. The goal is to speed up re-indexing on bigger chains by reducing fetching traffic, especially since IPFS can be slower than regular https calls.

* Stores fetched data in public.data tables
* Add `getData` methods from chainsauce to give event handlers access to db data
* Updates `log` input for parser method to `data`
* Explicitly declare indexing of metadata, allowlist data and allowlist records at the env of the ClaimStored event handler