### PR TITLE
Push Celo EAS contract addresses

### DIFF
--- a/seed.ts
+++ b/seed.ts
@@ -147,7 +147,7 @@ const main = async () => {
       },
       {
         chain_id: 42220,
-        contract_address: "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
+        contract_address: "0x72E1d8ccf5299fb36fEfD8CC4394B8ef7e98Af92",
         start_block: 27994577,
         contract_slug: easContractSlug,
       },

--- a/src/utils/getDeployment.ts
+++ b/src/utils/getDeployment.ts
@@ -47,8 +47,8 @@ export const getDeployment = (
       return {
         ...DEPLOYMENTS["42220"],
         startBlock: 22079540n,
-        easAddress: "",
-        schemaRegistryAddress: "",
+        easAddress: "0x72E1d8ccf5299fb36fEfD8CC4394B8ef7e98Af92",
+        schemaRegistryAddress: "0x5ece93bE4BDCF293Ed61FA78698B594F2135AF34",
         chainId,
       };
     case 42161:


### PR DESCRIPTION
Adds the EAS and Schema Registry contract addresses for Celo as documented here: https://docs.attest.org/docs/quick--start/contracts