### PR TITLE
fix: increase the retry delay in case a request fails

### DIFF
--- a/src/clients/rpcClientFactory.ts
+++ b/src/clients/rpcClientFactory.ts
@@ -55,6 +55,7 @@ export class UnifiedRpcClientFactory {
       return createHttpRpcClient({
         url: config.url,
         fetch: customFetch,
+        retryDelayMs: 1000,
       });
     }
 


### PR DESCRIPTION
increasing the delay when retrying a request will fix throughput errors, where we are performing too many requests to infura per second.