### PR TITLE
refactor(update_sales_values): make batch sales indexable

### DIFF
--- a/scripts/update_sales_values.ts
+++ b/scripts/update_sales_values.ts
@@ -1,6 +1,10 @@
 import "dotenv/config";
 
-import { HypercertExchangeAbi, getHypercertTokenId, parseClaimOrFractionId } from "@hypercerts-org/sdk";
+import {
+  HypercertExchangeAbi,
+  getHypercertTokenId,
+  parseClaimOrFractionId,
+} from "@hypercerts-org/sdk";
 import { createClient } from "@supabase/supabase-js";
 import { Chain, erc20Abi, getAddress, parseEventLogs, zeroAddress } from "viem";
 import {
@@ -37,6 +41,10 @@ const getChain = (chainId: number) => {
 };
 
 const main = async () => {
+  // This scripts has been deprecated as the transaction_hash is no longer unique for each sale
+  // since we introduced batching of sales
+  throw new Error("This script is deprecated");
+
   console.log("update_sales_values");
   // Get all sales rows
   // Create supabase client
@@ -166,7 +174,6 @@ const main = async () => {
       fee_amounts: result.fee_amounts.map((amount) => amount.toString()),
     };
   });
-
 
   // Upsert rows
   console.log("Upserting rows");

--- a/src/storage/storeTakerBid.ts
+++ b/src/storage/storeTakerBid.ts
@@ -27,7 +27,9 @@ export const TakerBid = z.object({
   transaction_hash: z.string(),
   currency_amount: z.bigint(),
   fee_amounts: z.array(z.bigint()),
-  fee_recipients: z.array(z.string().refine(isAddress, { message: "Invalid fee recipient address" })),
+  fee_recipients: z.array(
+    z.string().refine(isAddress, { message: "Invalid fee recipient address" }),
+  ),
 });
 
 export type TakerBid = z.infer<typeof TakerBid>;
@@ -145,8 +147,10 @@ export const storeTakerBid: StorageMethod<TakerBid> = async ({
       })
       .filter((x) => x !== null);
 
-    console.log("[IndexTakerBid] Deleting invalid orders", ordersToUpdate);
-    await supabaseData.from("marketplace_orders").upsert(ordersToUpdate);
+    if (ordersToUpdate.length > 0) {
+      console.log("[IndexTakerBid] Deleting invalid orders", ordersToUpdate);
+      await supabaseData.from("marketplace_orders").upsert(ordersToUpdate);
+    }
   }
 
   return [

--- a/supabase/migrations/20250805162719_sales_drop_unique_transaction_hash_requirement.sql
+++ b/supabase/migrations/20250805162719_sales_drop_unique_transaction_hash_requirement.sql
@@ -1,0 +1,3 @@
+-- Drop the unique constraint first
+alter table "public"."sales"
+    drop constraint "sales_transactionHash_key";


### PR DESCRIPTION
- Created a migration to drop the unique constraint on the sales transaction_hash. This was previously causing errors as since the introduction of batch sales through safe, multiple TakerBid events can take place within the same transaction.
- Marked the update_sales_values script as deprecated, explaining that transaction_hash is no longer unique due to sales batching.
- Improved formatting of imports for better readability.
- Added a check to ensure orders are only logged and upserted if there are updates in storeTakerBid.